### PR TITLE
Fix some bugs in `common` chart

### DIFF
--- a/.github/workflows/install-openstack-cinder.yaml
+++ b/.github/workflows/install-openstack-cinder.yaml
@@ -1,4 +1,4 @@
-name: Lint and install cinder chart
+name: Install cinder chart
 
 on:
   pull_request:
@@ -18,16 +18,8 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1
 
-      - name: setup minikube
-        uses: manusa/actions-setup-minikube@v2.4.2
-        with:
-          minikube version: "v1.24.0"
-          kubernetes version: "v1.23.0"
-          start args: --memory 6g --cpus=2 --addons ingress --cni=flannel
-          github token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: remove read permission from kube config file
-        run: sudo chmod go-r ~/.kube/config
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
 
       - name: use local disk
         run: tests/scripts/github-action-helper.sh use_local_disk_for_integration_test
@@ -51,7 +43,7 @@ jobs:
       - name: Install openstack-dep chart
         run: |
           helm dependency build charts/openstack-dep
-          helm install openstack-dependency charts/openstack-dep --namespace test-cinder --wait
+          helm install openstack-dependency charts/openstack-dep --namespace test-cinder --wait --timeout 600s
 
       - name: Install keystone chart
         run: |
@@ -60,8 +52,3 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --namespace test-cinder --target-branch main --charts charts/cinder --debug --helm-extra-args "--timeout 600s"
-
-      - name: setup tmate session for debugging when event is PR
-        if: failure() && github.event_name == 'pull_request'
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 60

--- a/.github/workflows/install-openstack-dep.yaml
+++ b/.github/workflows/install-openstack-dep.yaml
@@ -30,4 +30,4 @@ jobs:
           helm install openstack-password charts/password --namespace openstack-dep
 
       - name: Run chart-testing (install)
-        run: ct install --namespace openstack-dep --target-branch main --charts charts/openstack-dep --debug
+        run: ct install --namespace openstack-dep --target-branch main --charts charts/openstack-dep --debug --helm-extra-args "--timeout 600s"

--- a/.github/workflows/install-openstack-keystone.yaml
+++ b/.github/workflows/install-openstack-keystone.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install openstack-dep chart
         run: |
           helm dependency build charts/openstack-dep
-          helm install openstack-dependency charts/openstack-dep --namespace openstack-keystone --wait
+          helm install openstack-dependency charts/openstack-dep --namespace openstack-keystone --wait --timeout 600s
 
       - name: Run chart-testing (install)
         run: ct install --namespace openstack-keystone --target-branch main --charts charts/keystone --debug --helm-extra-args "--timeout 600s"

--- a/charts/cinder/Chart.yaml
+++ b/charts/cinder/Chart.yaml
@@ -13,7 +13,7 @@
 apiVersion: v2
 description: Openstack cinder service
 name: cinder
-version: 1.0.0
+version: 1.0.1
 home: https://github.com/kungze/kolla-helm
 maintainers:
   - name: Kungze

--- a/charts/cinder/README.md
+++ b/charts/cinder/README.md
@@ -10,7 +10,7 @@ $ helm repo add kolla-helm https://kungze.github.io/kolla-helm
 $ helm install openstack-password kolla-helm/password
 $ helm install openstack-dependency kolla-helm/openstack-dep
 $ helm install openstack-keystone kolla-helm/keystone
-$ helm install openstack-cinder kolla-helm/cinder --values ceph.enabled=false
+$ helm install openstack-cinder kolla-helm/cinder --set ceph.enabled=false
 ```
 
 ## Ceph Backend
@@ -73,10 +73,10 @@ required while the ceph backend was enabled.
 | `lvm.loop_device_name`       |  Loop Device Name           | The loop device's name                                                                                                       | `/dev/loop0`                 |
 | `lvm.loop_device_size`       | Loop Device Size            | The loop device's size, unit Mb                                                                                              | `2048`                       |
 | `lvm.loop_device_directory`  | Loop Device Directoyr       | The host directory save loop device file                                                                                     | `/var/lib/kolla-helm/cinder` |
-| `lvm.volume_type`            | Cinder Volume Type          | The cinder volume type name corresponding with lvm backend                                                                   | `lvm1`                       |
+| `lvm.volume_type`            | Cinder Volume Type          | The cinder volume type name corresponding with lvm backend                                                                   | `lvm`                       |
 | `lvm.lvm_target_helper`      | Cinder Lvm Target Helper    | Target user-land tool to use                                                                                                 | `tgtadm`                     |
 | `ceph.enabled`               | Enable Ceph                 | Whether or not enable ceph backend                                                                                           | `true`                       |
-| `ceph.volume_type`           | Cinder Volume Type          | The cinder volume type name corresponding with ceph backend                                                                  | `rbd1`                       |
+| `ceph.volume_type`           | Cinder Volume Type          | The cinder volume type name corresponding with ceph backend                                                                  | `rbd`                       |
 | `ceph.poolName`              | Pool Name                   | The ceph pool name which used to store the cinder volumes                                                                    | `volumes`                    |
 | `ceph.replicatedSize`        | Pool Replicated Size        | For a pool based on raw copies, specify the number of copies. A size of 1 indicates no redundancy.                           | `3`                          |
 | `ceph.failureDomain`         | Pool Failure Domain         | The failure domain will spread the replicas of the data across different failure zones                                       | `host`                       |

--- a/charts/cinder/templates/NOTES.txt
+++ b/charts/cinder/templates/NOTES.txt
@@ -1,4 +1,8 @@
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 
-** 请耐心等待 chart 部署完成 **
+** Please be patient while the chart is being deployed **
+
+You can use the below command to check whether or not all of related pods are ready.
+
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}

--- a/charts/cinder/templates/deployment-backup.yaml
+++ b/charts/cinder/templates/deployment-backup.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ceph.backup.enabled }}
+{{- if and .Values.ceph.enabled .Values.ceph.backup.enabled }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:

--- a/charts/cinder/values.schema.json
+++ b/charts/cinder/values.schema.json
@@ -155,7 +155,7 @@
                     "type": "string",
                     "description": "The cinder volume type name corresponding with lvm backend",
                     "title": "Cinder Volume Type",
-                    "default": "lvm1"
+                    "default": "lvm"
                 },
                 "lvm_target_helper": {
                     "form": true,
@@ -181,7 +181,7 @@
                     "type": "string",
                     "description": "The cinder volume type name corresponding with ceph backend",
                     "title": "Cinder Volume Type",
-                    "default": "rbd1"
+                    "default": "rbd"
                 },
                 "poolName": {
                     "form": true,

--- a/charts/cinder/values.yaml
+++ b/charts/cinder/values.yaml
@@ -63,14 +63,14 @@ lvm:
   ## @param lvm.loop_device_directory [t#Loop Device Directoyr] The host directory save loop device file
   loop_device_directory: /var/lib/kolla-helm/cinder
   ## @param lvm.volume_type [t#Cinder Volume Type] The cinder volume type name corresponding with lvm backend
-  volume_type: lvm1
+  volume_type: lvm
   ## @param lvm.lvm_target_helper [t#Cinder Lvm Target Helper] Target user-land tool to use
   lvm_target_helper: tgtadm
 ceph:
   ## @param ceph.enabled [t#Enable Ceph] Whether or not enable ceph backend
   enabled: true
   ## @param ceph.volume_type [t#Cinder Volume Type] The cinder volume type name corresponding with ceph backend
-  volume_type: rbd1
+  volume_type: rbd
   ## @param ceph.poolName [t#Pool Name] The ceph pool name which used to store the cinder volumes
   poolName: volumes
   ## @param ceph.replicatedSize [t#Pool Replicated Size] For a pool based on raw copies, specify the number of copies. A size of 1 indicates no redundancy.

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -13,7 +13,7 @@
 apiVersion: v2
 description: Openstack kolla helm common library
 name: common
-version: 1.0.2
+version: 1.0.3
 home: https://github.com/kungze/kolla-helm
 maintainers:
   - name: Kungze

--- a/charts/common/templates/manifests/_job_db_sync.tpl
+++ b/charts/common/templates/manifests/_job_db_sync.tpl
@@ -15,7 +15,7 @@ metadata:
 spec:
   template:
     spec:
-      activeDeadlineSeconds: 100
+      activeDeadlineSeconds: 200
       containers:
         - name: {{ printf "%s-%s" $serviceName "db-sync" | quote }}
           image: {{ $image | quote }}

--- a/charts/common/templates/manifests/_job_sync_rook_ceph_conf.tpl
+++ b/charts/common/templates/manifests/_job_sync_rook_ceph_conf.tpl
@@ -15,13 +15,6 @@ metadata:
 type: Opaque
 data:
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "ceph-monitor-endpoints"
-  namespace: {{ $envAll.Release.Namespace }}
-data:
----
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -39,24 +32,20 @@ spec:
           command:
             - /bin/sh
             - -c
-            - python /tmp/sync-ceph-cm-secrets.py
+            - python /tmp/sync-ceph-secrets.py
           env:
             - name: KUBERNETES_NAMESPACE
               value: {{ $envAll.Release.Namespace | quote }}
             - name: ROOK_CEPH_CLUSTER_NAMESPACE
               value: {{ $envAll.Values.ceph.cephClusterNamespace | quote }}
-            - name: ROOK_CEPH_MON_ENDPOINTS_CONFIGMAP
-              value: {{ printf "%s-mon-endpoints" $envAll.Values.ceph.cephClusterName }}
             - name: ROOK_CEPH_CLIENT_SECRET
               value: {{ printf "%s-client-%s" $envAll.Values.ceph.cephClusterName $envAll.Values.ceph.cephClientName | quote }}
-            - name: OS_CEPH_MON_CONFIGMAP
-              value: "ceph-monitor-endpoints"
             - name: OS_CEPH_CLIENT_SECRET
               value: {{ printf "ceph-%s" $envAll.Values.ceph.cephClientName | quote }}
           volumeMounts:
           - mountPath: /tmp
             name: pod-tmp
-          - mountPath: /tmp/sync-ceph-cm-secrets.py
+          - mountPath: /tmp/sync-ceph-secrets.py
             name: {{ printf "%s-bin" $serviceName | quote }}
             subPath: sync-ceph-cm-secrets.py
       restartPolicy: OnFailure

--- a/charts/common/templates/scripts/_ks_register_services.sh.tpl
+++ b/charts/common/templates/scripts/_ks_register_services.sh.tpl
@@ -5,7 +5,9 @@ set -ex
 PUBLIC_URL=""
 if [ -z "$INGRESS_URI" ]; then
     PUBLIC_URL=$INTERNAL_URL
-else
+elif [ "$API_VERSION" ]; then
+    PUBLIC_URL=$INGRESS_URI/$SERVICE_TYPE/$API_VERSION
+else 
     PUBLIC_URL=$INGRESS_URI/$SERVICE_TYPE/v3
 fi
 


### PR DESCRIPTION
1. In _job_db_sync, change the "ActiveDeadlinesecseconds" parameter from 100
   seconds to 200 seconds to avoid synchronization failure when there are
   too many tables.
2. Remove the code associated with sync_ceph_endpoint, which will be moved to
   openstack-dep chart because this is a common operation that only needs to
   be run once.
3. Add the API_VERSION variable, which you can define in the Register job to
   customize the version of the API.